### PR TITLE
Allow container.image to be null/empty

### DIFF
--- a/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
+++ b/src/Sdk/DTPipelines/Pipelines/ObjectTemplating/PipelineTemplateConverter.cs
@@ -316,7 +316,7 @@ namespace GitHub.DistributedTask.Pipelines.ObjectTemplating
 
             if (String.IsNullOrEmpty(result.Image))
             {
-                context.Error(value, "Container image cannot be empty");
+                return null;
             }
 
             return result;

--- a/src/Sdk/DTPipelines/workflow-v1.0.json
+++ b/src/Sdk/DTPipelines/workflow-v1.0.json
@@ -369,7 +369,7 @@
     "container-mapping": {
       "mapping": {
         "properties": {
-          "image": "non-empty-string",
+          "image": "string",
           "options": "non-empty-string",
           "env": "container-env",
           "ports": "sequence-of-non-empty-string",
@@ -401,8 +401,21 @@
       ],
       "one-of": [
         "non-empty-string",
-        "container-mapping"
+        "services-container-mapping"
       ]
+    },
+
+    "services-container-mapping": {
+      "mapping": {
+        "properties": {
+          "image": "non-empty-string",
+          "options": "non-empty-string",
+          "env": "container-env",
+          "ports": "sequence-of-non-empty-string",
+          "volumes": "sequence-of-non-empty-string",
+          "credentials": "container-registry-credentials"
+        }
+      }
     },
 
     "container-registry-credentials": {


### PR DESCRIPTION
For issue https://github.com/actions/runner/issues/265, A pull request https://github.com/actions/runner/pull/266/files was created which allows for container to be an empty string.

Since container is an alias for container.image. It makes sense to allow container.image to have empty values as well. 

Similar to the original pull request which was to allow jobs that run on public container, or no container within the same matrix, this would allow jobs that run on private container, or no container within the same matrix.